### PR TITLE
Add events

### DIFF
--- a/fabulation.py
+++ b/fabulation.py
@@ -146,6 +146,23 @@ class Node(object):
 
         return view, meta
 
+
+class Event(object):
+    def __init__( self, data ):
+        self._enter_event = data.pop('onEntrance',"")
+        self._exit_event = data.pop('onExit',"")
+
+    def render( self, name, nodes ):
+        meta = dict()
+        if self._enter_event:
+            meta['enter'] = "%s" % self._enter_event
+
+        if self._exit_event:
+            meta['exit'] = "%s" % self._exit_event
+
+        return dict(), meta
+
+
 def main():
     frame_file = "frame.html"
 
@@ -161,7 +178,7 @@ def main():
     with open(syu_in_file, "r") as i:
         yaml_dict = yaml.load( i.read() )
 
-    nodes = { name : Node( i, data, [ Text, Pic, Audio ] ) for i,(name,data) in enumerate(yaml_dict.items()) }
+    nodes = { name : Node( i, data, [ Text, Pic, Audio, Event ] ) for i,(name,data) in enumerate(yaml_dict.items()) }
 
     info = { node._ident : node.render( name, nodes ) for name, node in nodes.items() }
     view = [ v for i,(v,m) in info.items() ]

--- a/js/fabulation.js
+++ b/js/fabulation.js
@@ -117,8 +117,8 @@ function start_fabulation(meta)
                         $("#"+obj.id).trigger(obj["exit"])
                     })
                 }
-            }
-
+            },
+            start_scene : function(tgt) { }
         },        
         text : 
         {

--- a/js/fabulation.js
+++ b/js/fabulation.js
@@ -102,6 +102,24 @@ function start_fabulation(meta)
                 this.change_pic(tgt, "fullpic", ".bg")
             }
         },
+        event : 
+        {
+            init : function(obj)
+            {
+                if ("enter" in obj) {
+                    $("#"+obj.id).on("scene.entrance", function() {
+                        $("#"+obj.id).trigger(obj["enter"])
+                    })
+                }
+
+                if ("exit" in obj) {
+                    $("#"+obj.id).on("scene.exit", function() {
+                        $("#"+obj.id).trigger(obj["exit"])
+                    })
+                }
+            }
+
+        },        
         text : 
         {
             cur : "",
@@ -193,10 +211,12 @@ function start_fabulation(meta)
                     }
 
                     $("#"+tgt.id).fadeIn(fadetime)
+                    $("#"+tgt.id).trigger("scene.entrance")
                 }
 
                 if( this.cur )
                 {
+                    $("#"+this.cur).trigger("scene.exit")
                     $("#"+this.cur).fadeOut(fadetime, show_new_text.bind(this))
                 }
                 else


### PR DESCRIPTION
Adds javascript events to fabulation to expand interaction possibilities.

This adds the following new features:
- Scenes will now emit a custom JQuery event scene.entrance and scene.exit on entering or exiting the scene, respectively.
- The event is emitted from the <div> of the scene.
- Two new fields can be defined in the story yaml: onEntrance and onExit. The argument of these fields is a string naming an event that will be triggered on the corresponding scene.entrance or scene.exit event. The event will "bubble up" from the scene <div> through the DOM, where it can be parsed by other scripts.
